### PR TITLE
feat: adjust profile-related components and API, rename components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, Routes, Route } from 'react-router-dom'
-import { AuthContext } from './context/context'
 import { setAuthToken, getAuthToken } from './utils/utils'
 import Aos from 'aos'
 import 'aos/dist/aos.css'
@@ -14,10 +13,6 @@ import ProfilePage from './pages/ProfilePage'
 
 function App () {
   const [token, setToken] = useState(null)
-  const [user, setUser] = useState({
-    email: '',
-    nickname: ''
-  })
 
   const navigate = useNavigate()
 
@@ -40,21 +35,19 @@ function App () {
 
   return (
     <>
-      <AuthContext.Provider value={{ token, setToken, user, setUser }}>
-          {/* <Nav handleLogout={handleLogout} /> */}
-          <Routes>
-            <Route index element={<HomePage />} />
-            <Route path="nav" handleLogout={handleLogout} element={<Nav />} />
-            {/* <Route path={"/#AuthMail"}>
-            <Route path="AccountActivation" element={<AccountActivationPage />} />
-          </Route> */}
-            <Route path="/AuthMail/AccountActivation" element={<AccountActivationPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignupPage />} />
-            <Route path="/forgetpassword" element={<ForgetPasswordPage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-          </Routes>
-      </AuthContext.Provider>
+        {/* <Nav handleLogout={handleLogout} /> */}
+        <Routes>
+          <Route index element={<HomePage />} />
+          <Route path="nav" handleLogout={handleLogout} element={<Nav />} />
+          {/* <Route path={"/#AuthMail"}>
+          <Route path="AccountActivation" element={<AccountActivationPage />} />
+        </Route> */}
+          <Route path="/AuthMail/AccountActivation" element={<AccountActivationPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/forgetpassword" element={<ForgetPasswordPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Routes>
     </>
   )
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import ProfileMenu from '../components/ProfileMenu'
+import HeaderUserNav from './HeaderUserNav'
 import {
   Notifications
 }
@@ -84,7 +84,7 @@ export const HeaderUser = () => {
                 className="text-colors-fifth md:hidden">
                 <Notifications sx={{ fontSize: 30 }} />
             </Link>
-            <ProfileMenu />
+            <HeaderUserNav />
             {/* <UserMenu /> */}
         </header>
   )

--- a/src/components/HeaderUserNav.js
+++ b/src/components/HeaderUserNav.js
@@ -1,14 +1,12 @@
 import React, { useState } from 'react'
-import { UserMenu } from '../components/UserMenu'
+import { UserMenu } from './UserMenu'
 import Button from '@mui/material/Button'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
-import {
-  LogoutOutlined
-} from '@mui/icons-material'
+import { LogoutOutlined } from '@mui/icons-material'
 
-export default function ProfileMenu () {
+export default function HeaderUserNav () {
   const [anchorEl, setAnchorEl] = useState(null)
   const open = Boolean(anchorEl)
   const handleClick = (event) => {

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -5,7 +5,7 @@ import { ModalResetPwd, ModalPwdSuccess, ModalVerifySignup } from '../components
 import {
   CloseOutlined
 } from '@mui/icons-material'
-import ProfileMenu from './ProfileMenu'
+import HeaderUserNav from './HeaderUserNav'
 
 const Nav = () => {
   // const [isOpen, setIsOpen] = useState(false)
@@ -107,7 +107,7 @@ const Nav = () => {
             </li>
 
             <li>
-                <ProfileMenu />
+                <HeaderUserNav />
             </li>
 
         </nav>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,13 +1,13 @@
 import ProfileTab from './ProfileTab'
 import ProfileUser from './ProfileUser'
-import ProfileSidebars from './ProfileSidebars'
+import SideNav from './SideNav'
 
 export default function Profile () {
   return (
     <div
       className="viewContainer">
       <div className='hidden md:block relative'>
-        <ProfileSidebars />
+        <SideNav />
       </div>
       <div className='md:hidden'>
         <ProfileUser />

--- a/src/components/ProfileForm.js
+++ b/src/components/ProfileForm.js
@@ -1,54 +1,21 @@
-import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { editProfileApi, getProfileApi } from '../utils/api'
-import {
-  EmailOutlined,
-  PermIdentityOutlined
-}
-  from '@mui/icons-material'
+import { editProfileApi } from '../utils/api'
+import { useUserData } from '../context/context'
+import { EmailOutlined, PermIdentityOutlined } from '@mui/icons-material'
 
-export default function ProfileForm () {
-  const [userData, setUserData] = useState({
-    name: '',
-    account: '',
-    image: ''
-  })
+export default function ProfileForm ({ onSubmitSaveProfile }) {
+  const { userData, setUserData } = useUserData()
+  const { account, name } = userData
 
   const {
     register,
     handleSubmit,
-    formState: { errors },
-    reset
+    formState: { errors }
   } = useForm({
     defaultValues: {
-      name: userData.name
+      name
     }
   })
-
-  const getUserProfile = async () => {
-    try {
-      const { status: isSuccess, message, userdata } = await getProfileApi()
-      if (!isSuccess) {
-        console.log(message)
-        return
-      }
-      setUserData(userData => ({
-        ...userData,
-        name: userdata.Name,
-        account: userdata.Account,
-        image: userdata.Image
-      }))
-      reset({
-        name: userData.name
-      })
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
-  useEffect(() => {
-    getUserProfile()
-  }, [userData])
 
   /* Update profile */
   const onSubmit = async data => {
@@ -60,6 +27,10 @@ export default function ProfileForm () {
         return
       }
       console.log(message)
+      setUserData(userData => ({
+        ...userData,
+        name: data.name
+      }))
     } catch (error) {
       console.log(error)
     }
@@ -69,69 +40,44 @@ export default function ProfileForm () {
         <form
             className="flex flex-col mb-10 mt-11 lg:w-1/2 lg:mx-auto lg:mt-16 2xl:w-2/5"
             onSubmit={handleSubmit(onSubmit)}>
-
             {/* 姓名 */}
-            <label
-                className='labelTitle'
-                htmlFor="name">
-                姓名
-            </label>
+            <label className="labelTitle" htmlFor="name">姓名</label>
             <div className="relative">
-                <div
-                    className='inputImg'>
+                <div className="inputImg">
                     <PermIdentityOutlined sx={{ fontSize: 16 }} />
                 </div>
                 <input
-                    id='name'
+                    id="name"
                     className="inputInfo mb-2"
                     type="text"
-                    placeholder="請輸入更改姓名"
-                    value={userData.name}
+                    placeholder="站內顯示的暱稱，可隨時修改"
+                    // value={name}
                     {...register('name', {
                       required: {
                         value: true,
-                        message: '請輸入您的姓名!'
+                        message: '此欄不可留空'
                       }
                     })}
                 />
-                {/* <p className="text-xs mb-2 text-rose-600">
-                        {errors.name?.message}
-                    </p> */}
+                <p className="text-xs mb-2 text-rose-600">{errors.name?.message}</p>
             </div>
-
             {/* Email */}
-            <label
-                className='labelTitle mt-10'
-                htmlFor="account">
-                電子郵件
-            </label>
+            <label className="labelTitle mt-10" htmlFor="account">電子郵件</label>
             <div className="relative">
-                <div
-                    className='inputImg'>
+                <div className="inputImg">
                     <EmailOutlined sx={{ fontSize: 16 }} />
                 </div>
                 <input
                     id="account"
                     className="inputInfo mb-2"
                     type="email"
-                    placeholder="請輸入電子郵件"
-                    value="o***t@mail.com"
-                    {...register('account', {
-                      required: '此為必填欄位',
-                      pattern: {
-                        value: /^\S+@\S+$/i,
-                        message: '電子郵件格式有誤，請重新確認'
-                      }
-                    })}
+                    value={account}
+                    disabled="disabled"
                 />
             </div>
-
-            {/* 確認 BTN */}
+            {/* BTNs */}
             <div className='mt-10 flex justify-between items-center gap-[5%]'>
-                <div
-                    className="btn-primary w-1/2 text-center">
-                    更改密碼
-                </div>
+                <div className="btn-primary w-1/2 text-center">更改密碼</div>
                 <input
                     className="btn-primary w-1/2"
                     type="submit"

--- a/src/components/ProfileUser.js
+++ b/src/components/ProfileUser.js
@@ -1,24 +1,16 @@
-import userImg from '../image/userImg.svg'
-import {
-  BorderColorOutlined
-}
-  from '@mui/icons-material'
+import { useUserData } from '../context/context'
+import { BorderColorOutlined } from '@mui/icons-material'
 
 export default function ProfileUser () {
+  const { userData, setUserData } = useUserData()
+  const { name, image } = userData
+
   return (
-        <div
-            className="flex justify-center items-center gap-5 mb-8 mt-14 md:justify-start">
-            <img
-                className="rounded-full border card-shadow"
-                src={userImg}
-                alt="userImg"
-            />
+        <div className="flex justify-center items-center gap-5 mb-8 mt-14 md:justify-start">
+            <img className="rounded-full border card-shadow" src={image} alt="userImg"/>
             <div
                 className="flex flex-col gap-3 items-center">
-                <p
-                    className="font-bold">
-                    Candice Wu
-                </p>
+                <p className="font-bold">{name}</p>
                 <div className="flex items-center justify-center text-gray-400 text-xs gap-2 cursor-pointer">
                     <BorderColorOutlined sx={{ fontSize: 14 }} />
                     編輯頭像

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -1,18 +1,13 @@
 import React, { useState } from 'react'
 import ProfileUser from './ProfileUser'
 import ProfileTab from './ProfileTab'
-import ProfileSideGroup from './ProfileSideGroup.js'
+import SideNavGroup from './SideNavGroup.js'
 import PropTypes from 'prop-types'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
-import {
-  Home,
-  Person,
-  Notifications
-}
-  from '@mui/icons-material'
+import { Home, Person, Notifications } from '@mui/icons-material'
 
 const primary = '#40798C'
 const secondary = '#6AC1AC'
@@ -86,7 +81,7 @@ export default function ProfileSidebars () {
           icon={<Notifications sx={{ fontSize: 24, color: third }} />}
           iconPosition="start"
           label="通知" {...a11yProps(2)} />
-        <ProfileSideGroup />
+        <SideNavGroup />
       </Tabs>
 
       <TabPanel

--- a/src/components/SideNavGroup.js
+++ b/src/components/SideNavGroup.js
@@ -1,10 +1,7 @@
 import GroupCoverPhoto from '../image/Group_cover-photo.svg'
-import {
-  Add
-}
-  from '@mui/icons-material'
+import { Add } from '@mui/icons-material'
 
-export default function ProfileSideGroup () {
+export default function SideNavGroup () {
   return (
         <div className='flex flex-col'>
             <div

--- a/src/context/context.js
+++ b/src/context/context.js
@@ -1,9 +1,12 @@
 import { useContext, createContext } from 'react'
-import { getAuthToken } from '../utils/utils'
 
-/* 初始值為 null */
-export const AuthContext = createContext(null)
+/* User Profile 頁的 data */
+export const UserDataContext = createContext({
+  account: '',
+  name: '',
+  image: ''
+})
 
-export const useAuth = () => {
-  return useContext(AuthContext)
+export const useUserData = () => {
+  return useContext(UserDataContext)
 }

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -1,17 +1,58 @@
+import { useEffect, useState } from 'react'
 import { HeaderUser } from '../components/Header'
-import Profile from '../components/Profile'
+import { getProfileApi } from '../utils/api'
+import { UserDataContext } from '../context/context'
 import { FooterUser } from '../components/Footer'
+import ProfileTab from '../components/ProfileTab'
+import ProfileUser from '../components/ProfileUser'
+import SideNav from '../components/SideNav'
 
 export default function ProfilePage () {
+  const [userData, setUserData] = useState({
+    name: '',
+    account: '',
+    image: ''
+  })
+
+  const getUserProfile = async () => {
+    try {
+      const { status: isSuccess, message, userdata } = await getProfileApi()
+      if (!isSuccess) {
+        console.log(message)
+        return
+      }
+      setUserData(userData => ({
+        ...userData,
+        name: userdata.Name,
+        account: userdata.Account,
+        image: userdata.Image
+      }))
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  useEffect(() => {
+    getUserProfile()
+  }, [])
+
   return (
     <>
       <HeaderUser />
-      <div
-        className='pb-[111px] md:pb-20 md:ProfileFitFooter-md'>
-        <Profile />
-      </div>
-      <div
-        className='ProfileFitFooter'>
+      <UserDataContext.Provider value={ { userData, setUserData } }>
+        <div className='pb-[111px] md:pb-20 md:ProfileFitFooter-md'>
+          <div className="viewContainer">
+            <div className='hidden md:block relative'>
+              <SideNav />
+            </div>
+            <div className='md:hidden'>
+              <ProfileUser />
+              <ProfileTab />
+            </div>
+          </div>
+        </div>
+      </UserDataContext.Provider>
+      <div className='ProfileFitFooter'>
         <FooterUser />
       </div>
     </>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,21 +2,21 @@ import axios from 'axios'
 import { getAuthToken } from './utils'
 
 /* Interceptors: addgin token to header */
-// axios.interceptors.request.use(function (config) {
-//   // Do something before request is sent
-//   const newConfig = {
-//     ...config,
-//     headers: {
-//       ...config.headers,
-//       authorization: `Bearer ${getAuthToken()}`
-//     }
-//   }
-//   console.log('newConfig', newConfig.headers.authorization)
-//   return newConfig
-// }, function (error) {
-//   // Do something with request error
-//   return Promise.reject(error)
-// })
+axios.interceptors.request.use(function (config) {
+  // Do something before request is sent
+  const newConfig = {
+    ...config,
+    headers: {
+      ...config.headers,
+      authorization: `Bearer ${getAuthToken()}`
+    }
+  }
+  console.log('newConfig', newConfig.headers.authorization)
+  return newConfig
+}, function (error) {
+  // Do something with request error
+  return Promise.reject(error)
+})
 
 /* API config */
 const baseApiEndpoint = 'https://easysplit.rocket-coding.com/api'


### PR DESCRIPTION
feat: adjust profile-related components and API, rename common components

- 修掉 profile 頁重複 call api 的問題
- profile 頁 components 架構調整＆重串 api：現在 profile 會員資料那頁可以接到會員頭像、名稱、email，編輯送出後也可以更新
- 共通 components 命名修改